### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT="antenna-loadtests"
+PROJECT="antenna"
 OS := $(shell uname)
 HERE = $(shell pwd)
 PYTHON = python3
@@ -9,7 +9,7 @@ VENV_PIP = $(BIN)/pip3
 VENV_PYTHON = $(BIN)/python
 INSTALL = $(VENV_PIP) install
 
-URL_SERVER="https://$(PROJECT).dev.mozaws.net/submit"
+URL_SERVER="https://$(PROJECT).stage.mozaws.net/submit"
 
 .PHONY: all check-os install-elcapitan install build
 .PHONY: configure
@@ -53,7 +53,7 @@ configure: build
 
 #bash -c "source loadtest.env && URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 30"
 test:
-	bash -c "URL_SERVER=$(URL_SERVER) ailoads -v -d 30"
+	bash -c "URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 30"
 
 test-heavy: build
 	bash -c "source loadtest.env && URL_SERVER=$(URL_SERVER) $(BIN)/ailoads -v -d 300 -u 10"

--- a/loadtest.py
+++ b/loadtest.py
@@ -5,91 +5,89 @@ from ailoads.fmwk import scenario
 import utils
 
 URL_SERVER = os.getenv('URL_SERVER',
-                       'https://antenna.dev.mozaws.net/submit')
+                       'https://antenna.stage.mozaws.net/submit')
 DEBUG = False
 
 if DEBUG:
     utils._log_everything()
 
 
-@scenario(100)
-def test_crash_100k_compressed():
-    size = (100 * 1024)
-    raw_crash, dumps = utils.generate_sized_crashes(size)
+# Meomoized generated payloads
+CACHE = {}
+
+
+def memoize(fun):
+    """Decorates a function and memoizes it"""
+    def _memoize(*args, **kwargs):
+        key = repr((list(sorted(args)), list(sorted(kwargs.items()))))
+        if key not in CACHE:
+            ret = fun(*args, **kwargs)
+            CACHE[key] = ret
+        return CACHE[key]
+    return _memoize
+
+
+@memoize
+def get_payload_and_headers(size, compressed=False):
+    """Returns a payload and headers
+
+    :arg size: the size in bytes the payload should be
+    :arg compressed: whether or not to compress the payload
+
+    :returns: ``(payload, headers)``
+
+    """
     # Generate the payload and headers for a crash
-    payload, headers = utils.multipart_encode(raw_crash)
-    # POST the dump to Antenna
-    resp = utils.post_crash(URL_SERVER, payload, headers, compressed=True)
-    print("test_crash_100k_compressed: HTTP %s" % resp.status_code)
+    raw_crash, dumps = utils.generate_sized_crashes(size, compressed)
+
+    # Convert the raw crash metadata and dumps into a single dict
+    crash_payload = utils.assemble_crash_payload(raw_crash, dumps)
+
+    # Convert the crash payload dict into a multipart/form-encode byte stream
+    payload, headers = utils.multipart_encode(crash_payload)
+
+    # If we should compress it, compress the byte stream and add relevant
+    # header
+    if compressed:
+        payload = utils.compress(payload)
+        headers['Content-Encoding'] = 'gzip'
+
+    # Return payload and headers as a tuple
+    return payload, headers
+
+
+def run_test(name, size, compressed):
+    payload, headers = get_payload_and_headers(size, compressed=compressed)
+    resp = utils.post_crash(URL_SERVER, payload, headers, size)
+
+    print('%s: HTTP %s' % (name, resp.status_code))
     # Verify HTTP 200
     resp.raise_for_status()
     # Verify the response text contains a CrashID
     utils.verify_crashid(resp.text)
+
+
+@scenario(100)
+def test_crash_100k_compressed():
+    run_test('test_crash_100k_compressed', 100 * 1024, compressed=True)
 
 
 @scenario(0)
 def test_crash_150k_compressed():
-    size = (150 * 1024)
-    raw_crash, dumps = utils.generate_sized_crashes(size)
-    # Generate the payload and headers for a crash
-    payload, headers = utils.multipart_encode(raw_crash)
-    # POST the dump to Antenna
-    resp = utils.post_crash(URL_SERVER, payload, headers, compressed=True)
-    print("test_crash_150k_compressed: HTTP %s" % resp.status_code)
-    # Verify HTTP 200
-    resp.raise_for_status()
-    # Verify the response text contains a CrashID
-    utils.verify_crashid(resp.text)
+    run_test('test_crash_150k_compressed', 150 * 1024, compressed=True)
 
 
 @scenario(0)
 def test_crash_400k_uncompressed():
-    size = (400 * 1024)
-    raw_crash, dumps = utils.generate_sized_crashes(size)
-    crash_payload = utils.assemble_crash_payload(raw_crash, dumps)
-    payload, headers = utils.multipart_encode(crash_payload)
-    # POST the dump to Antenna
-    resp = utils.post_crash(URL_SERVER, payload, headers)
-    print("test_crash_400k_uncompressed: HTTP %s" % resp.status_code)
-    # Verify HTTP 200
-    resp.raise_for_status()
-    # Verify the response text contains a CrashID
-    utils.verify_crashid(resp.text)
+    run_test('test_crash_400k_uncompressed', 400 * 1024, compressed=False)
 
 
 @scenario(0)
 def test_crash_4mb_uncompressed():
-    size = (4 * 1024 * 1024)
-    raw_crash, dumps = utils.generate_sized_crashes(size)
-    crash_payload = utils.assemble_crash_payload(raw_crash, dumps)
-    payload, headers = utils.multipart_encode(crash_payload)
-
-    if len(payload) != size:
-        raise ValueError('payload size %s', len(payload))
-
-    # POST the dump to Antenna
-    resp = utils.post_crash(URL_SERVER, payload, headers)
-    print("test_crash_4mb_uncompressed: HTTP %s" % resp.status_code)
-    # Verify HTTP 200
-    resp.raise_for_status()
-    # Verify the response text contains a CrashID
-    utils.verify_crashid(resp.text)
+    run_test('test_crash_4mb_uncompressed', 4 * 1024 * 1024, compressed=False)
 
 
 @scenario(0)
 def test_crash_20mb_uncompressed():
-    size = (20 * 1024 * 1024)
-    raw_crash, dumps = utils.generate_sized_crashes(size)
-    crash_payload = utils.assemble_crash_payload(raw_crash, dumps)
-    payload, headers = utils.multipart_encode(crash_payload)
-
-    if len(payload) != size:
-        raise ValueError('payload size %s', len(payload))
-
-    # POST the dump to Antenna
-    resp = utils.post_crash(URL_SERVER, payload, headers)
-    print("test_crash_20mb_uncompressed: HTTP %s" % resp.status_code)
-    # Verify HTTP 200
-    resp.raise_for_status()
-    # Verify the response text contains a CrashID
-    utils.verify_crashid(resp.text)
+    run_test('test_crash_20mb_uncompressed', 20 * 1024 * 1024,
+             compressed=False)

--- a/loadtest.py
+++ b/loadtest.py
@@ -67,27 +67,27 @@ def run_test(name, size, compressed):
     utils.verify_crashid(resp.text)
 
 
-@scenario(100)
+@scenario(20)
 def test_crash_100k_compressed():
     run_test('test_crash_100k_compressed', 100 * 1024, compressed=True)
 
 
-@scenario(0)
+@scenario(20)
 def test_crash_150k_compressed():
     run_test('test_crash_150k_compressed', 150 * 1024, compressed=True)
 
 
-@scenario(0)
+@scenario(20)
 def test_crash_400k_uncompressed():
     run_test('test_crash_400k_uncompressed', 400 * 1024, compressed=False)
 
 
-@scenario(0)
+@scenario(20)
 def test_crash_4mb_uncompressed():
     run_test('test_crash_4mb_uncompressed', 4 * 1024 * 1024, compressed=False)
 
 
-@scenario(0)
+@scenario(20)
 def test_crash_20mb_uncompressed():
     run_test('test_crash_20mb_uncompressed', 20 * 1024 * 1024,
              compressed=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 six
 requests
-git+git://github.com/tarekziade/molotov.git@284e47562e17523b4504047dd05b570938596d58
+https://github.com/tarekziade/molotov/archive/284e47562e.zip


### PR DESCRIPTION
* remove a lot of DRY
* memoize payloads and headers since it doesn't make sense to generate new one
  for every test
* fix compressed tests--we want the final compressed payload to be of the
  specified size rather than the payload before compression (compressing
  'aaaa...' makes for a very small payload)
* switch from using -dev to -stage since that's now working
* fix the "make test" rule
* fix the PROJECT so that the default URL_SERVER works
* fix a bunch of tests that were sending the payload before assembling it which
  results in payloads that have no dumps (and are thus very small)
* add a check to post_crash to verify that the payload size is the expected
  size
* makes all the scenarios equally likely

This fixes a lot of correctness issues with the tests and gets them working on my local machine.

r?