### PR TITLE
Add support for multiple dumps per crash

### DIFF
--- a/loadtest.py
+++ b/loadtest.py
@@ -28,17 +28,31 @@ def memoize(fun):
 
 
 @memoize
-def get_payload_and_headers(size, compressed=False):
-    """Returns a payload and headers
+def get_payload_and_headers(size, dump_names=None, compressed=False):
+    """Returns a payload and headers ready for posting
 
     :arg size: the size in bytes the payload should be
+    :arg dump_names: list of dumps to include; default is
+        ``['upload_file_minidump']``
     :arg compressed: whether or not to compress the payload
 
     :returns: ``(payload, headers)``
 
     """
+    if not dump_names:
+        dump_names = ['upload_file_minidump']
+
     # Generate the payload and headers for a crash
-    raw_crash, dumps = utils.generate_sized_crashes(size, compressed)
+    raw_crash, dumps = utils.generate_sized_crashes(
+        size, dump_names=dump_names, compressed=compressed
+    )
+
+    # Make sure we have the specified dumps
+    assert list(sorted(dumps.keys())) == list(sorted(dump_names)), (
+        'Dumps are missing. There is a bug in the test code. %s vs. %s' % (
+            dumps.keys(), dump_names
+        )
+    )
 
     # Convert the raw crash metadata and dumps into a single dict
     crash_payload = utils.assemble_crash_payload(raw_crash, dumps)
@@ -52,13 +66,19 @@ def get_payload_and_headers(size, compressed=False):
         payload = utils.compress(payload)
         headers['Content-Encoding'] = 'gzip'
 
+    # Make sure the final payload size is correct
+    assert len(payload) == size, (
+        'Payload is not the right size! %s vs. %s' % (len(payload), size)
+    )
+
     # Return payload and headers as a tuple
     return payload, headers
 
 
-def run_test(name, size, compressed):
-    payload, headers = get_payload_and_headers(size, compressed=compressed)
-    resp = utils.post_crash(URL_SERVER, payload, headers, size)
+def run_test(name, size, dump_names=None, compressed=False):
+    payload, headers = get_payload_and_headers(size, dump_names=dump_names,
+                                               compressed=compressed)
+    resp = utils.post_crash(URL_SERVER, payload, headers)
 
     print('%s: HTTP %s' % (name, resp.status_code))
     # Verify HTTP 200
@@ -90,4 +110,16 @@ def test_crash_4mb_uncompressed():
 @scenario(20)
 def test_crash_20mb_uncompressed():
     run_test('test_crash_20mb_uncompressed', 20 * 1024 * 1024,
+             compressed=False)
+
+
+@scenario(20)
+def test_crash_400k_uncompressed_multiple_dumps():
+    run_test('test_crash_400k_uncompressed_multiple_dumps', 400 * 1024,
+             dump_names=[
+                 'upload_file_minidump',
+                 'upload_file_minidump_browser',
+                 'upload_file_minidump_flash1',
+                 'upload_file_minidump_flash2',
+             ],
              compressed=False)


### PR DESCRIPTION
* adds ability to generate a payload with multiple dumps--compressed or
  uncompressed
* moves test correctness assertions to get_payload_and_headers which only gets
  called once per payload type
* minor related code cleanup and improved documentation
* adds test_crash_400k_uncompressed_multiple_dumps test

Fixes #13